### PR TITLE
Fixed bug where desktop shows up on edit screen

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,7 @@ class App extends React.Component<RouteComponentProps, {}> {
         <Route path="/projects" exact={true} component={Projects} />
         <Route path="/create-project" component={CreateProject} />
         <Route path="/projects/:projectId/edit" component={EditProject} />
-        <Route path="/projects/{projectId}/desktop" component={ResourceDesktop} />
+        <Route path="/projects/:projectId/desktop" component={ResourceDesktop} />
         <Toaster />
       </div>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,8 +64,7 @@ class App extends React.Component<RouteComponentProps, {}> {
         <Route path="/projects" exact={true} component={Projects} />
         <Route path="/create-project" component={CreateProject} />
         <Route path="/projects/:projectId/edit" component={EditProject} />
-        <Route path="/projects/:projectId" component={ResourceDesktop} />
-        <Route path="/projects/{projectId}/desktop" component={EditProject} />
+        <Route path="/projects/{projectId}/desktop" component={ResourceDesktop} />
         <Toaster />
       </div>
     );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ class App extends React.Component<RouteComponentProps, {}> {
       }
       return config;
     });
-    
+
     // Redirect to login on 401
     axios.default.interceptors.response.use(
       response => response,
@@ -65,6 +65,7 @@ class App extends React.Component<RouteComponentProps, {}> {
         <Route path="/create-project" component={CreateProject} />
         <Route path="/projects/:projectId/edit" component={EditProject} />
         <Route path="/projects/:projectId" component={ResourceDesktop} />
+        <Route path="/projects/{projectId}/desktop" component={EditProject} />
         <Toaster />
       </div>
     );

--- a/src/pages/projects/Projects.tsx
+++ b/src/pages/projects/Projects.tsx
@@ -50,7 +50,7 @@ export class Projects extends React.Component<{}, IState> {
               return (
                 <tr key={project.id}>
                   <td className="align-middle">{project.name}</td>
-                  <td className="align-middle"><Link to={`/projects/${project.id}`}>Go to desktop</Link></td>
+                  <td className="align-middle"><Link to={`/projects/${project.id}/desktop`}>Go to desktop</Link></td>
                   <td className="align-middle text-right">
                     <Link
                       title="Edit project"
@@ -107,7 +107,7 @@ export class Projects extends React.Component<{}, IState> {
     if (window.confirm("Are you sure you want to delete this project?")) {
       try {
         const response = await axios.default.delete(`${getConfigManager().getConfig().apiBaseUrl}/api/v1/projects/${id}`);
-    
+
         if (response.status < 400) {
           this.loadProjects();
           getToastManager().addToast("Deleted project", "success");


### PR DESCRIPTION
Added new route path '/projects/{projectId}/desktop' to remove desktop view when visiting `/edit`.